### PR TITLE
강의 조회 서비스 로직 구현

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,org.mockito.MockitoAnnotations,openMocks" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureDomain.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureDomain.java
@@ -1,0 +1,30 @@
+package com.hhp.lectureapp.lecture.business;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class LectureDomain {
+    private long id;
+
+    private int userLimit;
+
+    private int userCount;
+
+    private boolean isFull;
+
+    private LocalDateTime openedAt;
+
+    private LocalDateTime createdAt;
+
+
+    public LectureDomain(Long id, int userLimit, int userCount, boolean isFull, LocalDateTime openedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.userLimit = userLimit;
+        this.userCount = userCount;
+        this.isFull = isFull;
+        this.openedAt = openedAt;
+        this.createdAt = createdAt;
+    }
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureRepository.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureRepository.java
@@ -1,7 +1,8 @@
 package com.hhp.lectureapp.lecture.business;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LectureRepository{
-    public List<LectureDomain> findAllByOpenAndNotFull();
+    List<LectureDomain> findAllByOpenedAtBeforeAndIsFull(LocalDateTime dateTime, Boolean isFull);
 }

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureRepository.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureRepository.java
@@ -1,0 +1,7 @@
+package com.hhp.lectureapp.lecture.business;
+
+import java.util.List;
+
+public interface LectureRepository{
+    public List<LectureDomain> findAllByOpenAndNotFull();
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureServiceImpl.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureServiceImpl.java
@@ -1,0 +1,16 @@
+package com.hhp.lectureapp.lecture.business;
+
+import com.hhp.lectureapp.lecture.controller.LectureService;
+import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class LectureServiceImpl implements LectureService {
+
+    @Override
+    public List<GetLectureDto> getLectureList() {
+        return List.of();
+    }
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureServiceImpl.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureServiceImpl.java
@@ -2,15 +2,23 @@ package com.hhp.lectureapp.lecture.business;
 
 import com.hhp.lectureapp.lecture.controller.LectureService;
 import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class LectureServiceImpl implements LectureService {
 
+    private final LectureRepository lectureRepository;
     @Override
     public List<GetLectureDto> getLectureList() {
-        return List.of();
+        return lectureRepository.findAllByOpenAndNotFull().stream()
+                .map(lecture -> new GetLectureDto(
+                        lecture.getId(),
+                        lecture.getUserCount(),
+                        lecture.getUserLimit())
+                ).toList();
     }
 }

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureServiceImpl.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/business/LectureServiceImpl.java
@@ -5,6 +5,7 @@ import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -14,7 +15,8 @@ public class LectureServiceImpl implements LectureService {
     private final LectureRepository lectureRepository;
     @Override
     public List<GetLectureDto> getLectureList() {
-        return lectureRepository.findAllByOpenAndNotFull().stream()
+        LocalDateTime now = LocalDateTime.now();
+        return lectureRepository.findAllByOpenedAtBeforeAndIsFull(now, false).stream()
                 .map(lecture -> new GetLectureDto(
                         lecture.getId(),
                         lecture.getUserCount(),

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/LectureController.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/LectureController.java
@@ -1,0 +1,24 @@
+package com.hhp.lectureapp.lecture.controller;
+
+
+import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/lectures")
+@RequiredArgsConstructor
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    @GetMapping
+    public ResponseEntity<List<GetLectureDto>> getLectureList() {
+        return null;
+    }
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/LectureController.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/LectureController.java
@@ -3,6 +3,8 @@ package com.hhp.lectureapp.lecture.controller;
 
 import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +21,6 @@ public class LectureController {
 
     @GetMapping
     public ResponseEntity<List<GetLectureDto>> getLectureList() {
-        return null;
+        return new ResponseEntity<>(lectureService.getLectureList(), HttpStatus.OK);
     }
 }

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/LectureService.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/LectureService.java
@@ -1,0 +1,9 @@
+package com.hhp.lectureapp.lecture.controller;
+
+import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
+
+import java.util.List;
+
+public interface LectureService {
+    public List<GetLectureDto> getLectureList();
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/dto/GetLectureDto.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/controller/dto/GetLectureDto.java
@@ -1,0 +1,8 @@
+package com.hhp.lectureapp.lecture.controller.dto;
+
+public record GetLectureDto (
+        long lectureId,
+        int userCount,
+        int userLimit
+){
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/Lecture.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/Lecture.java
@@ -1,0 +1,15 @@
+package com.hhp.lectureapp.lecture.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Lecture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/Lecture.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/Lecture.java
@@ -1,15 +1,42 @@
 package com.hhp.lectureapp.lecture.persistence;
 
+import com.hhp.lectureapp.lecture.business.LectureDomain;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
+@NoArgsConstructor
 public class Lecture {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 
+    private int userLimit;
+
+    private int userCount = 0;
+
+
+    private boolean isFull = false;
+
+    private LocalDateTime openedAt;
+
+    private LocalDateTime createdAt;
+
+    public LectureDomain toDomain() {
+        return new LectureDomain(id, userLimit, userCount, isFull, openedAt, createdAt);
+    }
+
+    public Lecture(int userLimit, int userCount, boolean isFull, LocalDateTime openedAt) {
+        this.userLimit = userLimit;
+        this.userCount = userCount;
+        this.isFull = isFull;
+        this.openedAt = openedAt;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureJpaRepository.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureJpaRepository.java
@@ -1,0 +1,11 @@
+package com.hhp.lectureapp.lecture.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface LectureJpaRepository extends JpaRepository<Lecture, Long> {
+    public List<Lecture> findAllByOpenedAtBeforeAndIsFull(LocalDateTime opened_at, boolean full);
+
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepository.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepository.java
@@ -1,4 +1,0 @@
-package com.hhp.lectureapp.lecture.persistence;
-
-public class LectureRepository {
-}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepository.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepository.java
@@ -1,0 +1,4 @@
+package com.hhp.lectureapp.lecture.persistence;
+
+public class LectureRepository {
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepositoryImpl.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.hhp.lectureapp.lecture.persistence;
+
+import com.hhp.lectureapp.lecture.business.LectureDomain;
+import com.hhp.lectureapp.lecture.business.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureRepositoryImpl implements LectureRepository {
+
+    private final LectureJpaRepository lectureJpaRepository;
+    @Override
+    public List<LectureDomain> findAllByOpenAndNotFull() {
+        return lectureJpaRepository.findAllByOpenedAtBeforeAndIsFull(LocalDateTime.now(), false).stream()
+                .map(Lecture::toDomain).toList();
+    }
+}

--- a/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepositoryImpl.java
+++ b/LectureApp/src/main/java/com/hhp/lectureapp/lecture/persistence/LectureRepositoryImpl.java
@@ -13,9 +13,10 @@ import java.util.List;
 public class LectureRepositoryImpl implements LectureRepository {
 
     private final LectureJpaRepository lectureJpaRepository;
+
     @Override
-    public List<LectureDomain> findAllByOpenAndNotFull() {
-        return lectureJpaRepository.findAllByOpenedAtBeforeAndIsFull(LocalDateTime.now(), false).stream()
+    public List<LectureDomain> findAllByOpenedAtBeforeAndIsFull(LocalDateTime dateTime, Boolean isFull) {
+        return lectureJpaRepository.findAllByOpenedAtBeforeAndIsFull(dateTime, isFull).stream()
                 .map(Lecture::toDomain).toList();
     }
 }

--- a/LectureApp/src/main/resources/application.properties
+++ b/LectureApp/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.password=
 spring.sql.init.platform=h2
 
 # JPA settings
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 spring.jpa.open-in-view=false

--- a/LectureApp/src/test/java/com/hhp/lectureapp/e2e/LectureTest.java
+++ b/LectureApp/src/test/java/com/hhp/lectureapp/e2e/LectureTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -28,13 +30,17 @@ public class LectureTest {
     @Autowired
     private LectureJpaRepository lectureJpaRepository;
 
+    private final List<Lecture> lectureList = new ArrayList<>();
     @BeforeEach
     public void setUp() throws Exception {
-        lectureJpaRepository.save(new Lecture(30, 0, false, LocalDateTime.now().minusDays(1L)));
-        lectureJpaRepository.save(new Lecture(20, 0, false, LocalDateTime.now().minusDays(1L)));
-        lectureJpaRepository.save(new Lecture(40, 40, true, LocalDateTime.now().minusDays(1L)));
-        lectureJpaRepository.save(new Lecture(40, 0, false, LocalDateTime.now().plusDays(1L)));
-        lectureJpaRepository.save(new Lecture(40, 40, false, LocalDateTime.now().plusDays(1L)));
+
+        lectureList.add(new Lecture(30, 0, false, LocalDateTime.now().minusDays(1L)));
+        lectureList.add(new Lecture(20, 0, false, LocalDateTime.now().minusDays(1L)));
+        lectureList.add(new Lecture(40, 40, true, LocalDateTime.now().minusDays(1L)));
+        lectureList.add(new Lecture(40, 0, false, LocalDateTime.now().plusDays(1L)));
+        lectureList.add(new Lecture(40, 40, false, LocalDateTime.now().plusDays(1L)));
+        lectureList.add(new Lecture(40, 30, false, LocalDateTime.now().minusDays(1L)));
+        lectureJpaRepository.saveAll(lectureList);
 
     }
 
@@ -42,9 +48,11 @@ public class LectureTest {
     @Test
     @DisplayName("강의 목록 조회 테스트 - 정상 동작")
     public void getAllOpenLectures() throws Exception {
+
+        int successSize = lectureList.stream().map(Lecture::toDomain).filter(lecture -> !lecture.isFull() && LocalDateTime.now().isAfter(lecture.getOpenedAt())).toList().size();
         mockMvc.perform(get("/lectures"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(2));
+                .andExpect(jsonPath("$.size()").value(successSize));
     }
 
 }

--- a/LectureApp/src/test/java/com/hhp/lectureapp/e2e/LectureTest.java
+++ b/LectureApp/src/test/java/com/hhp/lectureapp/e2e/LectureTest.java
@@ -1,0 +1,51 @@
+package com.hhp.lectureapp.e2e;
+
+
+import com.hhp.lectureapp.lecture.persistence.Lecture;
+import com.hhp.lectureapp.lecture.persistence.LectureJpaRepository;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LectureTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LectureJpaRepository lectureJpaRepository;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        lectureJpaRepository.save(new Lecture(30, 0, false, LocalDateTime.now().minusDays(1L)));
+        lectureJpaRepository.save(new Lecture(20, 0, false, LocalDateTime.now().minusDays(1L)));
+        lectureJpaRepository.save(new Lecture(40, 40, true, LocalDateTime.now().minusDays(1L)));
+        lectureJpaRepository.save(new Lecture(40, 0, false, LocalDateTime.now().plusDays(1L)));
+        lectureJpaRepository.save(new Lecture(40, 40, false, LocalDateTime.now().plusDays(1L)));
+
+    }
+
+
+    @Test
+    @DisplayName("강의 목록 조회 테스트 - 정상 동작")
+    public void getAllOpenLectures() throws Exception {
+        mockMvc.perform(get("/lectures"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2));
+    }
+
+}

--- a/LectureApp/src/test/java/com/hhp/lectureapp/e2e/LectureTest.java
+++ b/LectureApp/src/test/java/com/hhp/lectureapp/e2e/LectureTest.java
@@ -3,7 +3,6 @@ package com.hhp.lectureapp.e2e;
 
 import com.hhp.lectureapp.lecture.persistence.Lecture;
 import com.hhp.lectureapp.lecture.persistence.LectureJpaRepository;
-import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/LectureApp/src/test/java/com/hhp/lectureapp/unitTest/LectureUnitTest.java
+++ b/LectureApp/src/test/java/com/hhp/lectureapp/unitTest/LectureUnitTest.java
@@ -1,0 +1,51 @@
+package com.hhp.lectureapp.unitTest;
+
+
+import com.hhp.lectureapp.lecture.business.LectureDomain;
+import com.hhp.lectureapp.lecture.business.LectureRepository;
+import com.hhp.lectureapp.lecture.business.LectureServiceImpl;
+import com.hhp.lectureapp.lecture.controller.LectureService;
+import com.hhp.lectureapp.lecture.controller.dto.GetLectureDto;
+import com.hhp.lectureapp.lecture.persistence.LectureRepositoryImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LectureUnitTest {
+    @Mock
+    private LectureRepositoryImpl lectureRepository;
+
+    @InjectMocks
+    private LectureServiceImpl lectureService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);  // Mock 객체 초기화
+    }
+
+    @Test
+    @DisplayName("getLectureList() - 정상 동작")
+    public void getLectureListTest() {
+        List<LectureDomain> lectureDomainList = new ArrayList<>();
+        int size = 5;
+        for(long i = 0; i < size; i++){
+            lectureDomainList.add(new LectureDomain(i, 30, 20, false, LocalDateTime.now().minusDays(1L), LocalDateTime.now().minusDays(2L)));
+        }
+        given(lectureRepository.findAllByOpenedAtBeforeAndIsFull(any(LocalDateTime.class), any(Boolean.class))).willReturn(lectureDomainList);
+
+        List<GetLectureDto> response = lectureService.getLectureList();
+
+        assertEquals(response.size(), size);
+
+    }
+}


### PR DESCRIPTION
## 추가 사항
### 비즈니스 로직
- 강의 조회 요청에 강의 목록을 List로 반환
- 현재 신청할 수 있는 강의 목록을 반환
    - 열려 있는(openedAt)
    - 꽉차지 않은(isFull)

### 단위 테스트
- 요청에 따라 Domain을 Dto로 교체가 되었는지
- 제공된 List<Domain>의 사이즈와 Dto의 사이즈가 맞는지

### E2E 테스트
- 케이스에 따른 신청 가능한 강의 갯수 출력 여부
    - 열려 있으면서 꽉차지 않은
    - 열려 있으나 꽉찬
    - 열려 있지 않으면서 꽉차지 않은
    - 열려 있지 안흐면서 꽉찬 